### PR TITLE
Fixing relative paths for examples.

### DIFF
--- a/examples/gles/README.md
+++ b/examples/gles/README.md
@@ -5,7 +5,7 @@ It covers the following areas:
 * Simple 3D graphics
 * Handling controller input
 
-To build, source ../setenv.sh and then run make
+To build, source ../../setenv.sh and then run make
 
 The final package should include the following files:
 	toc.txt

--- a/examples/linux/README.md
+++ b/examples/linux/README.md
@@ -1,6 +1,6 @@
 
 This is an example of creating a simple command line program on the Steam Link
 
-To build, source ../setenv.sh and then run make
+To build, source ../../setenv.sh and then run make
 
 You should then enable ssh on your device and use scp to copy it on and then run it from an ssh session on the Steam Link.

--- a/examples/qt/README.md
+++ b/examples/qt/README.md
@@ -7,7 +7,7 @@ It covers the following areas:
 * Handling controller input
 * Simple styling
 
-To build, source ../setenv.sh and then run qmake and then run make
+To build, source ../../setenv.sh and then run qmake and then run make
 
 The final package should include the following files:
 	toc.txt

--- a/examples/sdl/README.md
+++ b/examples/sdl/README.md
@@ -5,7 +5,7 @@ It covers the following areas:
 * Simple 2D graphics
 * Handling controller input
 
-To build, source ../setenv.sh and then run make
+To build, source ../../setenv.sh and then run make
 
 The final package should include the following files:
 	toc.txt


### PR DESCRIPTION
The relative paths for all the example files are one parent directory off. 