### PR TITLE
replaced realpath with readlink -f

### DIFF
--- a/toolchain/bin/armv7a-cros-linux-gnueabi-addr2line
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-addr2line
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/addr2line" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-ar
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-ar
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/ar" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-as
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-as
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/as" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-c++
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-c++
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-c++" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-c++filt
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-c++filt
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/c++filt" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-clang
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-clang
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-clang" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-clang++
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-clang++
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-clang++" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-cpp
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-cpp
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-cpp" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-dwp
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-dwp
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/dwp" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-elfedit
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-elfedit
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/elfedit" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-g++
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-g++
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-g++" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gcc
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gcc
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-gcc" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gcc-4.9.x-google
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gcc-4.9.x-google
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-gcc-4.9.x-google" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gcc-ar
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gcc-ar
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-gcc-ar" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gcc-nm
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gcc-nm
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-gcc-nm" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gcc-ranlib
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gcc-ranlib
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-gcc-ranlib" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gccgo
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gccgo
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-gccgo" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gcov
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gcov
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-gcov" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gcov-4.9.x-google
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gcov-4.9.x-google
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-gcov" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gcov-tool
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gcov-tool
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/gcc-bin/4.9.x-google/armv7a-cros-linux-gnueabi-gcov-tool" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gdb
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gdb
@@ -1,5 +1,5 @@
 #!/bin/sh
-if ! base=$(realpath "$0" 2>/dev/null); then
+if ! base=$(readlink -f "$0" 2>/dev/null); then
   case $0 in
   /*) base=$0;;
   *)  base=${PWD:-`pwd`}/$0;;

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-gprof
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-gprof
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/gprof" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-ld
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-ld
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24/ld" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-ld.bfd
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-ld.bfd
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/ld.bfd" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-ld.gold
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-ld.gold
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/ld.gold" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-nm
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-nm
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/nm" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-objcopy
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-objcopy
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/objcopy" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-objdump
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-objdump
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/objdump" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-ranlib
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-ranlib
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/ranlib" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-readelf
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-readelf
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/readelf" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-run
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-run
@@ -1,5 +1,5 @@
 #!/bin/sh
-if ! base=$(realpath "$0" 2>/dev/null); then
+if ! base=$(readlink -f "$0" 2>/dev/null); then
   case $0 in
   /*) base=$0;;
   *)  base=${PWD:-`pwd`}/$0;;

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-size
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-size
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/size" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-strings
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-strings
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/strings" "$@"

--- a/toolchain/bin/armv7a-cros-linux-gnueabi-strip
+++ b/toolchain/bin/armv7a-cros-linux-gnueabi-strip
@@ -1,4 +1,4 @@
 #!/bin/sh
-base=$(realpath "$0")
+base=$(readlink -f "$0")
 basedir=${base%/*}
 exec "${basedir}/../usr/x86_64-pc-linux-gnu/armv7a-cros-linux-gnueabi/binutils-bin/2.24-gold/strip" "$@"


### PR DESCRIPTION
recent ubuntu distributions don't have this preinstalled and it's also no built-in
in the dash - which is the default shell in recent ubuntu distributions