### PR TITLE
Fix controller input for Qt example.

### DIFF
--- a/examples/qt/main.cpp
+++ b/examples/qt/main.cpp
@@ -61,11 +61,6 @@ static void LoadFonts()
 int main( int argc, char *argv[] )
 {
 	//
-	// Initialize SDL to set up display mode and scale
-	//
-	SDL_Init(SDL_INIT_VIDEO);
-
-	//
 	// Create the Qt application
 	//
 	// For simplicity, the entire application and support objects are created here on the stack


### PR DESCRIPTION
While trying out the SDK examples, I ran into a problem where the Qt sample would not respond to any input from my Steam Controller. With this patch, everything seems to work fine. Am I missing something here? SDL_INIT_VIDEO doesn't seem to be necessary or relevant here at all, and the Steam Link shell app doesn't call it either.
