### PR TITLE
Fixed an error in sound.cpp that was preventing mame4all example from building

### DIFF
--- a/examples/mame4all/src/sdl/sound.cpp
+++ b/examples/mame4all/src/sdl/sound.cpp
@@ -85,7 +85,7 @@ int osd_start_audio_stream(int stereo)
 
 #ifdef USE_SLAUDIO
 	s_pContext = SLAudio_CreateContext();
-	s_pStream = SLAudio_CreateStream(s_pContext, Machine->sample_rate, stream_cache_channels, bytes_per_frame);
+	s_pStream = SLAudio_CreateStream(s_pContext, Machine->sample_rate, stream_cache_channels, bytes_per_frame, false);
 	if (!s_pStream) {
 		logerror("Couldn't create audio stream\n");
 		Machine->sample_rate = 0;


### PR DESCRIPTION
mame4all was not able to be compiled due to a slight error in the parameters being passes into SLAudio_CreateStream.