### PR TITLE
Fix caveexpress build

### DIFF
--- a/examples/caveexpress/build_steamlink.sh
+++ b/examples/caveexpress/build_steamlink.sh
@@ -10,7 +10,7 @@ SRC="${TOP}/caveexpress-src"
 if [ ! -d "${SRC}" ]; then
 	git clone https://github.com/mgerhardy/caveexpress.git "${SRC}"
 fi
-git checkout 2.4
+git -C "${SRC}" checkout tags/2.4
 
 #
 # Build it


### PR DESCRIPTION
The git command for switching to version 2.4 of caveexpress was missing the path, so it was executed out of the repository. Also specify that we want to checkout a tag since there is no branch with name 2.4.

Fixes #29 and #54.