### PR TITLE
Symlink libgcc_s.so.1 to libgcc_s.so

### DIFF
--- a/rootfs/lib/libgcc_s.so
+++ b/rootfs/lib/libgcc_s.so
@@ -1,0 +1,1 @@
+libgcc_s.so.1


### PR DESCRIPTION
This fixes issues when compile scripts want to pass `-lgcc_s`. `ld` will find `libgcc_s.so`, but not `libgcc_s.so.1`.