### PR TITLE
Update build_steamlink.sh

### DIFF
--- a/examples/retroarch/build_steamlink.sh
+++ b/examples/retroarch/build_steamlink.sh
@@ -26,7 +26,7 @@ export PKG_CONF_PATH=pkg-config
 # Download the source
 #
 if [ ! -d "${SRC}" ]; then
-	git clone https://github.com/libretro/RetroArch.git "${SRC}"
+	git clone --single-branch -b "v1.7.2" https://github.com/libretro/RetroArch.git "${SRC}"
 fi
 
 #


### PR DESCRIPTION
RetroArch version 1.7.3 and up don't compile against this sdk (The problem has some thing to do with QT).